### PR TITLE
fix: load mastermind without ES modules

### DIFF
--- a/Mastermind/index.html
+++ b/Mastermind/index.html
@@ -9,8 +9,8 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="text/babel" data-type="module">
-      import MastermindApp from './mastermind.jsx';
+    <script type="text/babel" src="./mastermind.jsx"></script>
+    <script type="text/babel">
       ReactDOM.createRoot(document.getElementById('root')).render(<MastermindApp />);
     </script>
   </body>

--- a/Mastermind/mastermind.jsx
+++ b/Mastermind/mastermind.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+const { useMemo, useState } = React;
 
 // Mastermind – Single-file React component (TailwindCSS)
 // Default export so it can be previewed immediately.
@@ -106,7 +106,7 @@ function GuessRow({ palette, guess, onSetSlot, onSubmit, canSubmit, disabled, fe
   );
 }
 
-export default function MastermindApp() {
+function MastermindApp() {
   const [palette, setPalette] = useState(defaultPalette);
   const [length, setLength] = useState(4);
   const [attempts, setAttempts] = useState(10);
@@ -339,3 +339,4 @@ export default function MastermindApp() {
     </div>
   );
 }
+window.MastermindApp = MastermindApp;


### PR DESCRIPTION
## Summary
- load Mastermind React game via Babel script instead of ES modules
- expose MastermindApp globally and remove ES module syntax

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1307d4083339c3a5c67d3b886be